### PR TITLE
go.r59

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -173,7 +173,7 @@ func (self *Lexer) Len() int {
 }
 
 func (self *Lexer) Data() []int {
-	return self.buf.Slice(self.startPos, self.pos).Data()
+	return []int(*self.buf.Slice(self.startPos, self.pos))
 }
 
 func (self *Lexer) String() string {

--- a/lexer/regex.go
+++ b/lexer/regex.go
@@ -77,7 +77,7 @@ func (self *Regex) Matches(s string) []string {
 			res.Push(self.l.String())
 		}
 	}
-	return res.Data()
+	return []string(*res.Slice(0,res.Len()))
 }
 
 func (self *Regex) Replace(s string, f func(string) string) string {
@@ -93,7 +93,7 @@ func (self *Regex) Replace(s string, f func(string) string) string {
 		}
 	}
 	res.Push(string(buf[last:]))
-	return strings.Join(res.Data(), "")
+	return strings.Join([]string(*res.Slice(0,res.Len())), "")
 }
 
 func Match(re, s string) bool {

--- a/lexer/state.go
+++ b/lexer/state.go
@@ -45,7 +45,7 @@ func (self *BasicState) Move(c int) []State {
 
 func (self *BasicState) Close() []State {
 	res := make([]State, self.empty.Len())
-	for i, x := range self.empty.Data() {
+	for i, x := range *self.empty.Slice(0,self.empty.Len()) {
 		res[i] = x.(State)
 	}
 	return res

--- a/peg/peg.go
+++ b/peg/peg.go
@@ -114,7 +114,7 @@ func (self *ExtensibleExpr) Add(e Expr) {
 func (self *ExtensibleExpr) Match(m Position) (Position, interface{}) {
 	if len(self.e) != self.es.Len() {
 		newe := make(Or, self.es.Len())
-		for i, e := range self.es.Data() {
+		for i, e := range *self.es.Slice(0,self.es.Len()) {
 			newe[i] = e.(Expr)
 		}
 		self.e = newe
@@ -148,12 +148,12 @@ func (self *quantifiedExpr) Match(m Position) (Position, interface{}) {
 	for i := self.min; self.max == -1 || i < self.max; i++ {
 		cur, item = self.e.Match(last)
 		if cur.Failed() {
-			return last, res.Data()
+			return last, []interface{}(*res.Slice(0,res.Len()))
 		}
 		res.Push(item)
 		last = cur
 	}
-	return cur, res.Data()
+	return cur, []interface{}(*res.Slice(0,res.Len()))
 }
 
 func Quantify(e Expr, min, max int) Expr {


### PR DESCRIPTION
hello,

os.Errr and container/vector API changes...

the last one is pretty icky (all this casting and dereferencing...) []interface{}(foo) looks almost like a perl ascii art, but it makes compile 'go'

ypb

p.s. /actor compiles without modification, but apage fails on http.Conn... (as it's not req by golisp I did not investigate)
